### PR TITLE
Add templates for the editorial bot

### DIFF
--- a/.buffy/templates/close.md
+++ b/.buffy/templates/close.md
@@ -1,0 +1,5 @@
+:wave: This repository is only for review issues (`pre-review` and `review`) that have been created by our editorial infrastructure, and this issue appears not to be one of these.
+
+As such, this issue will be closed. If you're opening an issue as part of a review, please open a new issue instead in the software repository associated with the submission that you are reviewing.
+
+Many thanks!

--- a/.buffy/templates/goodbye.md
+++ b/.buffy/templates/goodbye.md
@@ -1,0 +1,28 @@
+:tada::tada::tada: Congratulations on your paper acceptance! :tada::tada::tada:
+
+If you would like to include a link to your paper from your README use the following code snippets:
+
+```
+Markdown:
+[![DOI](https://proceedings.juliacon.org/papers/10.21105/jcon.00{{issue_id}}/status.svg)](https://doi.org/10.21105/jcon.00{{issue_id}})
+
+HTML:
+<a style="border-width:0" href="https://doi.org/10.21105/jcon.00{{issue_id}}">
+  <img src="https://proceedings.juliacon.org/papers/10.21105/jcon.00{{issue_id}}/status.svg" alt="DOI badge" >
+</a>
+
+reStructuredText:
+.. image:: https://proceedings.juliacon.org/papers/10.21105/jcon.00{{issue_id}}/status.svg
+   :target: https://doi.org/10.21105/jcon.00{{issue_id}}
+```
+
+This is how it will look in your documentation:
+
+[![DOI](https://proceedings.juliacon.org/papers/10.21105/jcon.00{{issue_id}}/status.svg)](https://doi.org/10.21105/jcon.00{{issue_id}})
+
+**We need your help!**
+
+JuliaCon Proceedings is a community-run journal and relies upon volunteer effort. If you'd like to support us please consider doing either one (or both) of the the following:
+
+- Volunteering to review for us sometime in the future. You can add your name to the reviewer list here: https://forms.gle/yANMe4c9YmuW9MWcA
+- Making a small donation to support our running costs here: https://numfocus.salsalabs.org/donate-to-jcon

--- a/.buffy/templates/post-review_checklist.md
+++ b/.buffy/templates/post-review_checklist.md
@@ -1,0 +1,17 @@
+# Post-Review Checklist for Editor and Authors
+
+## Additional Author Tasks After Review is Complete
+- Double check authors and affiliations (including ORCIDs)
+- Make a release of the software with the latest changes from the review and post the version number here. This is the version that will be used in the JuliaCon Proceedings paper.
+- Archive the release on Zenodo/figshare/etc and post the DOI here.
+- Make sure that the title and author list (including ORCIDs) in the archive match those in the JuliaCon Proceedings paper.
+- Make sure that the license listed for the archive is the same as the software license.
+
+## Editor Tasks Prior to Acceptance
+- [ ] Read the text of the paper and offer comments/corrections (as either a list or a pull request)
+- [ ] Check that the archive title, author list, version tag, and the license are correct
+- [ ] Set archive DOI with ``@editorialbot set <DOI here> as archive``
+- [ ] Set version with ``@editorialbot set <version here> as version``
+- [ ] Double check rendering of paper with ``@editorialbot generate pdf``
+- [ ] Specifically check the references with ``@editorialbot check references`` and ask author(s) to update as needed
+- [ ] Recommend acceptance with ``@editorialbot recommend-accept``

--- a/.buffy/templates/pre-review_welcome.md
+++ b/.buffy/templates/pre-review_welcome.md
@@ -1,0 +1,13 @@
+Hello human, I'm @{{bot_name}}, a robot that can help you with some common editorial tasks.
+
+For a list of things I can do to help you, just type:
+
+```
+@{{bot_name}} commands
+```
+
+For example, to regenerate the paper pdf after making changes in the paper source files, type:
+
+```
+@{{bot_name}} generate pdf
+```

--- a/.buffy/templates/review_started.md
+++ b/.buffy/templates/review_started.md
@@ -1,0 +1,1 @@
+OK, I've started the review over in https://github.com/JuliaCon/proceedings-review/issues/{{review_issue_id}}.

--- a/.buffy/templates/review_welcome.md
+++ b/.buffy/templates/review_welcome.md
@@ -1,0 +1,13 @@
+Hello humans, I'm @{{bot_name}}, a robot that can help you with some common editorial tasks.
+
+For a list of things I can do to help you, just type:
+
+```
+@{{bot_name}} commands
+```
+
+For example, to regenerate the paper pdf after making changes in the paper source files, type:
+
+```
+@{{bot_name}} generate pdf
+```

--- a/.buffy/templates/reviewer_checklist.md
+++ b/.buffy/templates/reviewer_checklist.md
@@ -1,0 +1,42 @@
+## Review checklist for @{{sender}}
+
+### Conflict of interest
+
+- [ ] I confirm that I have read the [JuliaCon conflict of interest policy](https://proceedings.juliacon.org/guide/authors#coi) and that: I have no COIs with reviewing this work or that any perceived COIs have been waived by JCon for the purpose of this review.
+
+### Code of Conduct
+
+- [ ] I confirm that I read and will adhere to the [JuliaCon code of conduct](https://proceedings.juliacon.org/coc).
+
+### General checks
+
+- [ ] **Repository:** Is the source code for this software available at the [{{target-repository}}]({{target-repository}})?
+- [ ] **License:** Does the repository contain a plain-text LICENSE or COPYING file with the contents of an [OSI approved](https://opensource.org/licenses/alphabetical) software license?
+- [ ] **Contribution and authorship:** Has the submitting author ({{author-handle}}) made major contributions to the software? Does the full list of paper authors seem appropriate and complete?
+
+### Functionality
+
+- [ ] **Installation:** Does installation proceed as outlined in the documentation?
+- [ ] **Functionality:** Have the functional claims of the software been confirmed?
+- [ ] **Performance:** If there are any performance claims of the software, have they been confirmed? (If there are no claims, please check off this item.)
+
+### Documentation
+
+- [ ] **A statement of need**: Do the authors clearly state what problems the software is designed to solve and who the target audience is?
+- [ ] **Installation instructions:** Is there a clearly-stated list of dependencies? Ideally these should be handled with an automated package management solution.
+- [ ] **Example usage:** Do the authors include examples of how to use the software (ideally to solve real-world analysis problems).
+- [ ] **Functionality documentation:** Is the core functionality of the software documented to a satisfactory level (e.g., API method documentation)?
+- [ ] **Automated tests:** Are there automated tests or manual steps described so that the functionality of the software can be verified?
+- [ ] **Community guidelines:** Are there clear guidelines for third parties wishing to 1) Contribute to the software 2) Report issues or problems with the software 3) Seek support
+
+### Paper format
+
+- [ ] **Authors:** Does the `paper.tex` file include a list of authors with their affiliations?
+- [ ] **A statement of need:** Does the paper have a section titled 'Statement of need' that clearly states what problems the software is designed to solve, who the target audience is, and its relation to other work?
+- [ ] **References:**  Do all archival references that should have a DOI list one (e.g., papers, datasets, software)?
+
+### Content
+
+- [ ] **Context:** is the scientific context motivating the work correctly presented?
+- [ ] **Methodology:** is the approach taken in the work justified, presented with enough details and reference to reproduce it?
+- [ ] **Results:** are the results presented and compared to approaches with similar goals?

--- a/.buffy/templates/reviewers_list.md
+++ b/.buffy/templates/reviewers_list.md
@@ -1,0 +1,1 @@
+You can take a look at the list of people that have already agreed to review for JCON [here](https://bit.ly/jcon-reviewers).


### PR DESCRIPTION
This PR adds all the templates needed for the different editorial bot responders